### PR TITLE
fixed row column issue, drop and keep blocks

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -54,10 +54,10 @@ setMethod(
     rows = paste(unlist(object@rows), collapse = ", ")
     columns = paste(unlist(object@columns), collapse = ", ")
     expvar = round(object@explained_variance * 100, 2)
-    str = paste("Rows(",
-                rows,
-                ")-Columns(",
+    str = paste("Columns(",
                 columns,
+                ")-Rows(",
+                rows,
                 ") explains ",
                 expvar,
                 "% of the overall explained variance",

--- a/R/pla.R
+++ b/R/pla.R
@@ -61,10 +61,9 @@ pla <- function(x,
 
   # get explained variance for each block
   blocks <- lapply(blocks, function(block) {
-    cols <- block@columns
     block@explained_variance <- .explained_variance(eigen$values,
                                                     eigen$vectors,
-                                                    cols,
+                                                    block@columns,
                                                     expvar)
     return(block)
   })
@@ -173,7 +172,6 @@ pla.keep_blocks <- function(x, blocks, block_indizes) {
   block_indizes <- 1:length(blocks)
   return(pla.drop_blocks(x, blocks, block_indizes))
 }
-
 #' @title Drop Blocks
 #'
 #' Used to remove each variable from the original data set which is part of
@@ -198,8 +196,11 @@ pla.keep_blocks <- function(x, blocks, block_indizes) {
 #' data <- pla.drop_blocks(data, obj$blocks, c(1))
 #' @export
 pla.drop_blocks <- function(x, blocks, block_indizes) {
-  #for (idx in block_indizes) {
-  #  x <- x[,-blocks[[idx]]@variables, drop = FALSE]
-  #}
+  indizes <- vector()
+  for (idx in block_indizes) {
+    indizes <- c(indizes, blocks[[idx]]@columns)
+  }
+
+  x <- x[,-indizes, drop = FALSE]
   return(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,26 +9,26 @@
   blocks <- list()
   violated <- c()
   for (idx in 1:nrow(x)) {
-    columns <- .get_row_structure(x[idx, ])
-    block_idx <- .get_block_index(blocks, columns)
+    rows <- .get_column_structure(x[, idx])
+    block_idx <- .get_block_index(blocks, rows)
     violated <- unique(c(violated, block_idx$violates))
 
     if (block_idx$equals == -1) {
-      block <- new("Block", rows = c(idx), columns = columns)
+      block <- new("Block", rows = rows, columns = c(idx))
       blocks[[length(blocks)+1]] <- block
     } else {
-      blocks[[block_idx$equals]]@rows <- c(blocks[[block_idx$equals]]@rows, idx)
+      blocks[[block_idx$equals]]@columns <- c(blocks[[block_idx$equals]]@columns, idx)
     }
   }
 
   # remove blocks that violate the n x n structure
-  uncontained_rows = c()
+  uncontained_columns = c()
   if (length(blocks) > 0) {
     idx <- 1
     for (i in 1:length(blocks)) {
       block <- blocks[[idx]]
-      if ((length(block@rows) != length(block@columns)) || (length(intersect(block@columns, violated)) > 0)) {
-        uncontained_rows <- unique(c(uncontained_rows, block@rows))
+      if ((length(block@columns) != length(block@rows)) || (length(intersect(block@rows, violated)) > 0)) {
+        uncontained_columns <- unique(c(uncontained_columns, block@columns))
         blocks[[idx]] <- NULL
       } else {
         idx <- idx+1
@@ -36,9 +36,9 @@
     }
   }
 
-  # add a new 1x1 block for each row that is not contained within any block
-  for (row_nr in uncontained_rows) {
-    blocks[[length(blocks)+1]] <- new("Block", rows = c(row_nr), columns = c(row_nr))
+  # add a new 1x1 block for each column that is not contained within any block
+  for (column_nr in uncontained_columns) {
+    blocks[[length(blocks)+1]] <- new("Block", rows = vector(), columns = c(column_nr))
   }
 
   return(blocks)
@@ -46,9 +46,9 @@
 
 # returns the index of the block containing the exact columns
 # returns -1 if no block was found
-# returns the column indexes of blocks that can be confirmed to violate the block structure based on the new columns
-# (e.g. one block contains columns 2 and 8 --> if this functions retrieves c(8,9), the required structure cannot be given since 9 is not part of c(2,8))
-.get_block_index <- function(blocks, columns) {
+# returns the row indexes of blocks that can be confirmed to violate the block structure based on the new columns
+# (e.g. one block contains rows 2 and 8 --> if this functions retrieves c(8,9), the required structure cannot be given since 9 is not part of c(2,8))
+.get_block_index <- function(blocks, rows) {
   violates <- vector() # indexes of blocks that have a confirmed violated structure
   equals <- -1 # index of block that has the same structure
 
@@ -56,10 +56,10 @@
     for (idx in 1:length(blocks)) {
       block <- blocks[[idx]]
 
-      if (setequal(block@columns, columns)) {
+      if (setequal(block@rows, rows)) {
         equals <- idx
       } else {
-        violates <- c(violates, intersect(block@columns, columns))
+        violates <- c(violates, intersect(block@rows, rows))
       }
     }
   }
@@ -67,20 +67,20 @@
   return <- list("equals" = equals, "violates" = violates)
 }
 
-# checks if a vector has a continous sequence of 1s
-.get_row_structure <- function(vector) {
-  columns <- vector()
+# checks where the rows are that contain 0s
+.get_column_structure <- function(vector) {
+  rows <- vector()
 
   if (length(vector) > 0) {
     for (idx in 1:length(vector)) {
       value <- vector[idx]
       if (value == 0) {
-          columns <- c(columns, idx)
+          rows <- c(rows, idx)
       }
     }
   }
 
-  return(columns)
+  return(rows)
 }
 
 .explained_variance <- function(eigen_values, eigen_vectors, discard_cols, type = "approx") {


### PR DESCRIPTION
The misuse of columns and rows is fixed, now. This enables correct calculation of the explained variances.

Moreover, the drop and keep blocks methods have been updated. They work with indizes fine.